### PR TITLE
VisualFoxPro dbf types need 263 byte added in the header for dbc data…

### DIFF
--- a/dBASE.NET/Dbf.cs
+++ b/dBASE.NET/Dbf.cs
@@ -223,6 +223,15 @@
 
             // Write field descriptor array terminator.
             writer.Write((byte)0x0d);
+
+            // Emanuele Bonin 22/03/2025
+            // For visualFoxPro DBF Table there are other 263 bytes to add to the header
+            // that is the path to the dbc that belong the table (all 0x00 for no databases)
+            bool isVFP = header.Version == DbfVersion.VisualFoxPro || header.Version == DbfVersion.VisualFoxProWithAutoIncrement;
+            if (isVFP) {
+                for (int i = 0; i < 263; i++) writer.Write((byte)0);
+            }
+
         }
 
         private void WriteRecords(BinaryWriter writer)

--- a/dBASE.NET/Dbf3Header.cs
+++ b/dBASE.NET/Dbf3Header.cs
@@ -26,10 +26,14 @@ namespace dBASE.NET
 		internal override void Write(BinaryWriter writer, List<DbfField> fields, List<DbfRecord> records)
 		{
 			this.LastUpdate = DateTime.Now;
-			// Header length = header fields (32b ytes)
-			//               + 32 bytes for each field
-      //               + field descriptor array terminator (1 byte)
-			this.HeaderLength = (ushort)(32 + fields.Count * 32 + 1);
+            // Header length = header fields (32b ytes)
+            //               + 32 bytes for each field
+            //               + field descriptor array terminator (1 byte)
+            // Emanuele Bonin 22/03/2025
+            // For visualFoxPro DBF Table there are other 263 bytes to add to the header
+			// that is the path to the dbc that belong the table (all 0x00 for no databases)
+			bool isVFP = this.Version == DbfVersion.VisualFoxPro || this.Version == DbfVersion.VisualFoxProWithAutoIncrement;
+            this.HeaderLength = (ushort)(32 + fields.Count * 32 + 1 + (isVFP ? 263 : 0));
 			this.NumRecords = (uint)records.Count;
 			this.RecordLength = 1;
 			foreach (DbfField field in fields)


### PR DESCRIPTION
While creating a visualFoxPro Dbf type, the header is not complete. So the dbf cannot be opened by visualfoxpro ide because VFP dbf files need some extra bytes in the header to describe the dbc database to which the folder eventually belongs